### PR TITLE
Replace path by filepath

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
@@ -53,7 +53,7 @@ func initConfig() {
 			os.Exit(1)
 		}
 
-		viper.AddConfigPath(path.Join(home, "fleex"))
+		viper.AddConfigPath(filepath.Join(home, "fleex"))
 		viper.SetConfigName("config")
 	}
 

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -59,14 +59,14 @@ func Start(fleetName, command string, delete bool, input, outputPath, chunksFold
 
 	timeStamp := strconv.FormatInt(time.Now().UnixNano(), 10)
 	// TODO: use a proper temp folder function so that it can run on windows too
-	tempFolder := path.Join("/tmp", timeStamp)
+	tempFolder := filepath.Join("/tmp", timeStamp)
 
 	if chunksFolder != "" {
 		tempFolder = chunksFolder
 	}
 
 	// Make local temp folder
-	tempFolderInput := path.Join(tempFolder, "input")
+	tempFolderInput := filepath.Join(tempFolder, "input")
 	// Create temp folder
 	utils.MakeFolder(tempFolder)
 	utils.MakeFolder(tempFolderInput)
@@ -119,7 +119,7 @@ loop:
 				re = 1
 			}
 			if counter%(linesPerChunk+re) == 0 {
-				utils.StringToFile(path.Join(tempFolderInput, "chunk-"+fleetName+"-"+strconv.Itoa(x)), strings.Join(asd[0:counter], "\n")+"\n")
+				utils.StringToFile(filepath.Join(tempFolderInput, "chunk-"+fleetName+"-"+strconv.Itoa(x)), strings.Join(asd[0:counter], "\n")+"\n")
 				asd = nil
 				x++
 				counter = 0
@@ -156,7 +156,7 @@ loop:
 				boxName := l.Label
 
 				// Send input file via SCP
-				err := scp.NewSCP(sshutils.GetConnection(l.IP, port, username, password).Client).SendFile(path.Join(tempFolderInput, "chunk-"+boxName), "/tmp/fleex-"+timeStamp+"-chunk-"+boxName)
+				err := scp.NewSCP(sshutils.GetConnection(l.IP, port, username, password).Client).SendFile(filepath.Join(tempFolderInput, "chunk-"+boxName), "/tmp/fleex-"+timeStamp+"-chunk-"+boxName)
 				if err != nil {
 					utils.Log.Fatal("Failed to send file: ", err)
 				}
@@ -169,7 +169,7 @@ loop:
 				sshutils.RunCommand(finalCommand+"; rm -rf /tmp/fleex-"+timeStamp+"-chunk-"+boxName, l.IP, port, username, password)
 
 				// Now download the output file
-				err = scp.NewSCP(sshutils.GetConnection(l.IP, port, username, password).Client).ReceiveFile("/tmp/fleex-"+timeStamp+"-chunk-out-"+boxName, path.Join(tempFolder, "chunk-out-"+boxName))
+				err = scp.NewSCP(sshutils.GetConnection(l.IP, port, username, password).Client).ReceiveFile("/tmp/fleex-"+timeStamp+"-chunk-out-"+boxName, filepath.Join(tempFolder, "chunk-out-"+boxName))
 				if err != nil {
 					utils.Log.Fatal("Failed to get file: ", err)
 				}
@@ -203,10 +203,10 @@ loop:
 
 	// TODO: Get rid of bash and do this using Go
 
-	utils.RunCommand("cat " + path.Join(tempFolder, "*") + " > " + outputPath)
+	utils.RunCommand("cat " + filepath.Join(tempFolder, "*") + " > " + outputPath)
 
 	if chunksFolder == "" {
-		utils.RunCommand("rm -rf " + path.Join(tempFolder, "chunk-out-*"))
+		utils.RunCommand("rm -rf " + filepath.Join(tempFolder, "chunk-out-*"))
 	}
 
 }

--- a/pkg/sshutils/sshutils.go
+++ b/pkg/sshutils/sshutils.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"os"
 	"os/user"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -23,7 +23,7 @@ type Connection struct {
 
 func GetLocalPublicSSHKey() string {
 	publicSsh := viper.GetString("public-ssh-file")
-	rawKey := utils.FileToString(path.Join(getHomeDir(), ".ssh", publicSsh))
+	rawKey := utils.FileToString(filepath.Join(getHomeDir(), ".ssh", publicSsh))
 	retString := strings.ReplaceAll(rawKey, "\r\n", "")
 	retString = strings.ReplaceAll(retString, "\n", "")
 
@@ -31,7 +31,7 @@ func GetLocalPublicSSHKey() string {
 }
 
 func SSHFingerprintGen(publicSSH string) string {
-	rawKey := utils.FileToString(path.Join(getHomeDir(), ".ssh", publicSSH))
+	rawKey := utils.FileToString(filepath.Join(getHomeDir(), ".ssh", publicSSH))
 
 	// Parse the key, other info ignored
 	pk, _, _, _, err := ssh.ParseAuthorizedKey([]byte(rawKey))
@@ -153,7 +153,7 @@ func Connect(addr, user, password string) (*Connection, error) {
 	sshConfig := &ssh.ClientConfig{
 		User: user,
 		Auth: []ssh.AuthMethod{
-			publicKeyFile(path.Join(getHomeDir(), ".ssh", privateSsh)), // todo replace with rsa
+			publicKeyFile(filepath.Join(getHomeDir(), ".ssh", privateSsh)), // todo replace with rsa
 		},
 		HostKeyCallback: ssh.HostKeyCallback(func(hostname string, remote net.Addr, key ssh.PublicKey) error { return nil }),
 	}


### PR DESCRIPTION
Hi, "path" uses "/" as path separator regardless of the platform where we are compiling which may have undesired effects, better use "filepath" which is cross-platform. I tweeted once about an app that "stopped" working on Windows, the reason was exactly that.

https://twitter.com/melardev/status/1327761725664489472

Someone also blogged about it:
https://parsiya.net/blog/2019-03-09-path.join-considered-harmful/
