### PR TITLE
fix: add missing utils import to digitalocean_service.go

### DIFF
--- a/pkg/services/digitalocean_service.go
+++ b/pkg/services/digitalocean_service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/FleexSecurity/fleex/pkg/models"
 	"github.com/FleexSecurity/fleex/pkg/provider"
 	"github.com/FleexSecurity/fleex/pkg/sshutils"
+	"github.com/FleexSecurity/fleex/pkg/utils"
 	"github.com/digitalocean/godo"
 )
 


### PR DESCRIPTION
## Summary

Add missing `utils` import that was dropped during merge.

## Problem

PR #71 (pagination fix) was merged after PR #74 (fleet name matching), which overwrote the imports section and dropped the `utils` import. This breaks the build:

```
pkg/services/digitalocean_service.go:148:6: undefined: utils
pkg/services/digitalocean_service.go:287:6: undefined: utils
pkg/services/digitalocean_service.go:329:6: undefined: utils
pkg/services/digitalocean_service.go:372:6: undefined: utils
```

## Fix

Add `"github.com/FleexSecurity/fleex/pkg/utils"` to the imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)